### PR TITLE
Correct the typo in flag name

### DIFF
--- a/HFM/decisions/BEL.txt
+++ b/HFM/decisions/BEL.txt
@@ -84,7 +84,7 @@ political_decisions = {
 					NOT = { any_owned_province = { is_colonial = yes } }
 					raider_group_doctrine = 1
 					year = 1884 
-					NOT = { has_global_flag = colonial_railroading_disbaled }
+					NOT = { has_global_flag = colonial_railroading_disabled }
 				}
 			}
 		}


### PR DESCRIPTION
There's a typo in one of the flag references in Belgium's events. This PR corrects it.